### PR TITLE
Add pprof handlers to HTTPS interface

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"time"
 
+	// Enable pprof profiles
+	_ "net/http/pprof"
+
 	docker "github.com/docker/engine-api/client"
 	"github.com/dollarshaveclub/furan/lib"
 	"github.com/gorilla/mux"


### PR DESCRIPTION
This will enable CPU & memory profiles with the pprof Go tool.