### PR TITLE
Serve pprof on a different port

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -55,6 +55,7 @@ type DBconfig struct {
 type Serverconfig struct {
 	HTTPSPort           uint
 	GRPCPort            uint
+	PPROFPort           uint
 	HTTPSAddr           string
 	GRPCAddr            string
 	Concurrency         uint


### PR DESCRIPTION
This also actually exposes pprof. A previous commit assumed that pprof
was exposed with the existing mux, but it wasn't.