### PR TITLE
Back Github repo tarballs with files (closes #23)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -111,7 +111,7 @@ func build(cmd *cobra.Command, args []string) {
 		clierr("Error getting dockercfg: %v", err)
 	}
 
-	gf := lib.NewGitHubFetcher(gitConfig.Token)
+	gf := lib.NewGitHubFetcher(gitConfig.Token, serverConfig.DiskCacheDir)
 	dc, err := docker.NewEnvClient()
 	if err != nil {
 		clierr("error creating Docker client: %v", err)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,6 +56,7 @@ func init() {
 	serverCmd.PersistentFlags().UintVar(&serverConfig.S3PresignTTL, "s3-error-log-presign-ttl", 60*24, "Presigned error log URL TTL in minutes (0 to disable)")
 	serverCmd.PersistentFlags().UintVar(&serverConfig.GCIntervalSecs, "gc-interval", 3600, "GC (garbage collection) interval in seconds")
 	serverCmd.PersistentFlags().StringVar(&serverConfig.DockerDiskPath, "docker-storage-path", "/var/lib/docker", "Path to Docker storage for monitoring free space (optional)")
+	serverCmd.PersistentFlags().StringVar(&serverConfig.DiskCacheDir, "disk-cache-dir", "/tmp", "Where to store temporary data")
 	RootCmd.AddCommand(serverCmd)
 }
 
@@ -126,7 +127,7 @@ func server(cmd *cobra.Command, args []string) {
 		log.Fatalf("error creating Docker client: %v", err)
 	}
 
-	gf := lib.NewGitHubFetcher(gitConfig.Token)
+	gf := lib.NewGitHubFetcher(gitConfig.Token, serverConfig.DiskCacheDir)
 	osm := lib.NewS3StorageManager(awsConfig, mc, logger)
 	is := lib.NewDockerImageSquasher(logger)
 	s3errcfg := lib.S3ErrorLogConfig{

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,7 +56,7 @@ func init() {
 	serverCmd.PersistentFlags().UintVar(&serverConfig.S3PresignTTL, "s3-error-log-presign-ttl", 60*24, "Presigned error log URL TTL in minutes (0 to disable)")
 	serverCmd.PersistentFlags().UintVar(&serverConfig.GCIntervalSecs, "gc-interval", 3600, "GC (garbage collection) interval in seconds")
 	serverCmd.PersistentFlags().StringVar(&serverConfig.DockerDiskPath, "docker-storage-path", "/var/lib/docker", "Path to Docker storage for monitoring free space (optional)")
-	serverCmd.PersistentFlags().StringVar(&serverConfig.DiskCacheDir, "disk-cache-dir", "/tmp", "Where to store temporary data")
+	serverCmd.PersistentFlags().StringVar(&serverConfig.DiskCacheDir, "disk-cache-dir", os.TempDir(), "Where to store temporary data")
 	RootCmd.AddCommand(serverCmd)
 }
 

--- a/lib/builder.go
+++ b/lib/builder.go
@@ -230,6 +230,7 @@ func (ib *ImageBuilder) Build(ctx context.Context, req *BuildRequest, id gocql.U
 	if err != nil {
 		return "", err
 	}
+	defer contents.Close()
 	var dp string
 	if req.Build.DockerfilePath == "" {
 		dp = "Dockerfile"

--- a/lib/config.go
+++ b/lib/config.go
@@ -58,6 +58,7 @@ type Serverconfig struct {
 	PPROFPort           uint
 	HTTPSAddr           string
 	GRPCAddr            string
+	DiskCacheDir        string
 	Concurrency         uint
 	Queuesize           uint
 	VaultTLSCertPath    string

--- a/lib/github_fetch.go
+++ b/lib/github_fetch.go
@@ -114,6 +114,11 @@ func (gf *GitHubFetcher) stripTarPrefix(input io.ReadCloser) (io.ReadCloser, err
 		h, err := intar.Next()
 		if err != nil {
 			if err == io.EOF {
+				// Rewind the file so it can now be
+				// read.
+				if _, err := output.Seek(0, 0); err != nil {
+					return nil, err
+				}
 				return output, nil
 			}
 			return nil, fmt.Errorf("error reading input tar entry: %v", err)

--- a/lib/github_fetch.go
+++ b/lib/github_fetch.go
@@ -159,7 +159,7 @@ type tempTarball struct {
 }
 
 func newTempTarball() (*tempTarball, error) {
-	f, err := ioutil.TempFile("/tmp", "furan-github-tarball")
+	f, err := ioutil.TempFile("", "furan-github-tarball")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Github repos were passed around with in-memory io.Readers. When
dealing with large repositories, this overhead can be very large,
especially when handling concurrent jobs. According to a pprof profile
of Furan, its memory usage can exceed 500MB for significant periods of
time.

This changeset introduces a `tempTarball`, which is a disk-backed
tempfile implementing `io.ReadCloser` that has custom `.Close()`
behavior: the underlying file is deleted upon closing. `GithubFetcher`
was changed to back all tarballs with `tempTarball`. Additionally, a
`.Close()` call is made everywhere Github archives are downloaded.