### PR TITLE
Strip Github tar file prefixes in a stream

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -111,7 +111,7 @@ func build(cmd *cobra.Command, args []string) {
 		clierr("Error getting dockercfg: %v", err)
 	}
 
-	gf := lib.NewGitHubFetcher(gitConfig.Token, serverConfig.DiskCacheDir)
+	gf := lib.NewGitHubFetcher(gitConfig.Token)
 	dc, err := docker.NewEnvClient()
 	if err != nil {
 		clierr("error creating Docker client: %v", err)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,7 +56,6 @@ func init() {
 	serverCmd.PersistentFlags().UintVar(&serverConfig.S3PresignTTL, "s3-error-log-presign-ttl", 60*24, "Presigned error log URL TTL in minutes (0 to disable)")
 	serverCmd.PersistentFlags().UintVar(&serverConfig.GCIntervalSecs, "gc-interval", 3600, "GC (garbage collection) interval in seconds")
 	serverCmd.PersistentFlags().StringVar(&serverConfig.DockerDiskPath, "docker-storage-path", "/var/lib/docker", "Path to Docker storage for monitoring free space (optional)")
-	serverCmd.PersistentFlags().StringVar(&serverConfig.DiskCacheDir, "disk-cache-dir", os.TempDir(), "Where to store temporary data")
 	RootCmd.AddCommand(serverCmd)
 }
 
@@ -127,7 +126,7 @@ func server(cmd *cobra.Command, args []string) {
 		log.Fatalf("error creating Docker client: %v", err)
 	}
 
-	gf := lib.NewGitHubFetcher(gitConfig.Token, serverConfig.DiskCacheDir)
+	gf := lib.NewGitHubFetcher(gitConfig.Token)
 	osm := lib.NewS3StorageManager(awsConfig, mc, logger)
 	is := lib.NewDockerImageSquasher(logger)
 	s3errcfg := lib.S3ErrorLogConfig{

--- a/lib/builder.go
+++ b/lib/builder.go
@@ -230,7 +230,6 @@ func (ib *ImageBuilder) Build(ctx context.Context, req *BuildRequest, id gocql.U
 	if err != nil {
 		return "", err
 	}
-	defer contents.Close()
 	var dp string
 	if req.Build.DockerfilePath == "" {
 		dp = "Dockerfile"

--- a/lib/config.go
+++ b/lib/config.go
@@ -58,7 +58,6 @@ type Serverconfig struct {
 	PPROFPort           uint
 	HTTPSAddr           string
 	GRPCAddr            string
-	DiskCacheDir        string
 	Concurrency         uint
 	Queuesize           uint
 	VaultTLSCertPath    string

--- a/lib/github_fetch_test.go
+++ b/lib/github_fetch_test.go
@@ -1,0 +1,75 @@
+package lib
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"testing"
+)
+
+func TestTarPrefixStripper(t *testing.T) {
+	tarballBuf := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(tarballBuf)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "prefix/file1",
+		Size: 9,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write([]byte("contents1")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "prefix/file2",
+		Size: 9,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write([]byte("contents2")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := newTarPrefixStripper(ioutil.NopCloser(tarballBuf))
+	tarReader := tar.NewReader(reader)
+
+	header1, err := tarReader.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header1.Name != "file1" {
+		t.Fatalf("invalid file name found in tar header")
+	}
+	contents1, err := ioutil.ReadAll(tarReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents1) != "contents1" {
+		t.Fatalf("invalid file contents")
+	}
+
+	header2, err := tarReader.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header2.Name != "file2" {
+		t.Fatalf("invalid file name found in tar header")
+	}
+	contents2, err := ioutil.ReadAll(tarReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents2) != "contents2" {
+		t.Fatalf("invalid file contents")
+	}
+}


### PR DESCRIPTION
Previously, the tar file prefixes would be stripped in one go, which
requires filling up an entire buffer, regardless of whether it is
in-memory or file backed. The implementation has now been changed to
use a pipe, so tar file prefixes are stripped lazily when the `.Read`
method is called on a `tarPrefixStripper`. Since a pipe is now used, memory
usage will now be minimal because the tarball is read as needed and
all processing is performed on the fly.