### PR TITLE
Log previously swallowed githubfetch error

### DIFF
--- a/lib/github_fetch/github_fetch.go
+++ b/lib/github_fetch/github_fetch.go
@@ -95,8 +95,13 @@ func (gf *GitHubFetcher) getArchive(archiveURL *url.URL) (io.Reader, error) {
 }
 
 func (gf *GitHubFetcher) debugWriteTar(contents []byte) {
-	f, err := ioutil.TempFile("", "output-tar")
+	prefix := "output-tar"
+	f, err := ioutil.TempFile("", prefix)
+	if err != nil {
+		log.Printf("debug: error opening temporary file prefix:%s err:%v", prefix, err)
+	}
 	defer f.Close()
+
 	log.Printf("debug: saving tar output to %v", f.Name())
 	_, err = f.Write(contents)
 	if err != nil {


### PR DESCRIPTION
An error value was being assigned to an err variable, but nothing was being done with it. This PR adds logging for the previously-swallowed error.