### PR TITLE
Create release Makefile task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ furan
 lib/models.pb.go
 lib/testdata/*.tar.gz
 local_dev_secrets.local.json
+build
+releases

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: furan release
+
+furan:
+	go install github.com/dollarshaveclub/furan
+
+release:
+	rm -rf build releases
+	mkdir -p releases build/furan-linux-amd64 build/furan-darwin-amd64
+
+	GOOS=linux GOARCH=amd64 go build -o build/furan-linux-amd64/furan \
+		github.com/dollarshaveclub/furan
+	GOOS=darwin GOARCH=amd64 go build -o build/furan-darwin-amd64/furan \
+		github.com/dollarshaveclub/furan
+
+	tar -C build -c furan-linux-amd64 | gzip -c > releases/furan-linux-amd64.tar.gz
+	tar -C build -c furan-darwin-amd64 | gzip -c > releases/furan-darwin-amd64.tar.gz


### PR DESCRIPTION
This commit introduces a Makefile task that creates a Furan release
for amd64 darwin & linux platforms. The output of the task is two
gzipped tarballs (one per platform) can be uploaded to Github.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dollarshaveclub/furan/46)
<!-- Reviewable:end -->
