### PR TITLE
docker compose: add default/fake api key required for docker compose

### DIFF
--- a/local_dev_secrets.json
+++ b/local_dev_secrets.json
@@ -5,5 +5,6 @@
   "secret/production/furan/aws/secret_access_key": "bar",
   "secret/production/furan/github/token": "asdf",
   "secret/production/furan/dockercfg": "{}",
-  "secret/production/furan/sumologic/url": "https://example.com"
+  "secret/production/furan/sumologic/url": "https://example.com",
+  "secret/production/furan/newrelic/api_key": "some-api-key"
 }


### PR DESCRIPTION
Not having this value in vault causes Furan to terminate. 

Just throwing up this PR as a workaround for https://github.com/dollarshaveclub/furan/issues/56, if anyone needs a fix until the underlying issue is resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dollarshaveclub/furan/60)
<!-- Reviewable:end -->
