### PR TITLE
helm: use explicit boolean guards for flags

### DIFF
--- a/.helm/charts/furan/templates/deployment.yaml
+++ b/.helm/charts/furan/templates/deployment.yaml
@@ -58,17 +58,17 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - /go/bin/furan
-        {{ if eq .Values.vault.useTokenBasedAuth true }}
+        {{ if eq .Values.vault.useTokenAuth true }}
           - -k
         {{ end }}
-        {{ if eq .Values.initializeDb true }}
+        {{ if eq .Values.db.initialize true }}
           - -i
         {{ end }}
-        {{ if .Values.dbNodes }}
-          - -n
-          - {{ .Values.dbNodes }}
-        {{ else }}
+        {{ if eq .Values.db.useConsulDiscovery true }}
           - -z
+        {{ else }}
+          - -n
+          - {{ .Values.db.nodes }}
         {{ end }}
           - -f
           - {{ .Values.kafkaBrokers }}
@@ -76,13 +76,13 @@ spec:
           - -x
           - {{ .Values.vault.prefix }}
         {{ end }}
-        {{ if .Values.vault.k8s_auth }}
+        {{ if eq .Values.vault.useK8sAuth true }}
           - '--vault-k8s-jwt-path'
           - /var/run/secrets/kubernetes.io/serviceaccount/token
           - '--vault-k8s-role'
           - '{{ .Values.vault.role }}'
           - '--vault-k8s-auth-path'
-          - '{{ .Values.vault.auth_path }}'
+          - '{{ .Values.vault.authPath }}'
         {{ end }}
           - server
           - --log-to-sumo=false
@@ -109,8 +109,10 @@ spec:
           value: unix:///var/run/docker.sock
         - name: VAULT_ADDR
           value: {{ .Values.vault.addr }}
+      {{ if eq .Values.vault.useTokenAuth true }}
         - name: VAULT_TOKEN
           value: {{ .Values.vault.token }}
+      {{ end }}
         - name: CONSUL_HTTP_ADDR
           value: {{ .Values.consulAddr }}
         ports:

--- a/.helm/charts/furan/values.yaml
+++ b/.helm/charts/furan/values.yaml
@@ -25,12 +25,15 @@ service:
   httpHealthcheckPath: /health
   performanceProfilingPort: 4003
 
-dbNodes: "scylladb"
-initializeDb: true
+db:
+  useConsulDiscovery: false
+  nodes: "scylladb"
+  initialize: true
 kafkaBrokers: "kafka-furan:9092"
 
 vault:
-  useTokenBasedAuth: true
+  useTokenAuth: true
+  useK8sAuth: false
   addr: "http://vault:8200"
   token: "root"
 


### PR DESCRIPTION
There seems to be some implicit behavior during `helm upgrade` that will basically merge values from the default value file found from the chart if the externally supplied value file does not contain the corresponding value. 

This PR adds a boolean value to specify whether we should us consul discovery or use the supplied list of db nodes. It also adds some explicit equality checks to better understand the types of certain values in a template. 