### PR TITLE
Build not necessary error filtering

### DIFF
--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -673,12 +673,12 @@ func (ib *ImageBuilder) PushBuildToS3(ctx context.Context, imageid string, req *
 	if !ok {
 		return fmt.Errorf("cannot push build to s3: span missing from context")
 	}
-	pushSpan := tracer.StartSpan("image_builder.push", tracer.ChildOf(parentSpan.Context()))
-	defer pushSpan.Finish(tracer.WithError(err))
 	csha, err := ib.getCommitSHA(ctx, req.Build.GithubRepo, req.Build.Ref)
 	if err != nil {
 		return err
 	}
+	pushSpan := tracer.StartSpan("image_builder.push", tracer.ChildOf(parentSpan.Context()))
+	defer pushSpan.Finish(tracer.WithError(err))
 	info, _, err := ib.c.ImageInspectWithRaw(ctx, imageid)
 	if err != nil {
 		return err

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -413,7 +413,7 @@ func (ib *ImageBuilder) dobuild(ctx context.Context, req *lib.BuildRequest, rbi 
 	err2 := ib.saveOutput(ctx, Build, output) // we want to save output even if error
 	if err != nil {
 		le := output[len(output)-1]
-		dockerBuildError := fmt.Errorf("build failed: %v", le.Message)
+		dockerBuildError := fmt.Errorf("build failed: %v, %(v) ", err, le.Message)
 		if le.EventError.ErrorType == lib.BuildEventError_FATAL && ib.s3errorcfg.PushToS3 {
 			ib.logf(ctx, "pushing failed build log to S3: %v", id.String())
 			loc, err3 := ib.saveEventLogToS3(ctx, req.Build.GithubRepo, req.Build.Ref, Build, output)

--- a/lib/grpc/grpc.go
+++ b/lib/grpc/grpc.go
@@ -322,11 +322,11 @@ func (gr *GrpcServer) syncBuild(ctx context.Context, req *lib.BuildRequest) (out
 		if failed {
 			eet = lib.BuildEventError_FATAL
 			gr.mc.BuildFailed(req.Build.GithubRepo, req.Build.Ref, userError)
+			rootSpan.Finish(tracer.WithError(err))
 		} else {
 			eet = lib.BuildEventError_NO_ERROR
 			gr.mc.BuildSucceeded(req.Build.GithubRepo, req.Build.Ref)
 		}
-		rootSpan.Finish(tracer.WithError(err))
 		if err := gr.totalDuration(ctx, req); err != nil {
 			gr.logger.Printf("error pushing total duration: %v", err)
 		}
@@ -357,6 +357,7 @@ func (gr *GrpcServer) syncBuild(ctx context.Context, req *lib.BuildRequest) (out
 			gr.logf("failBuild: error publishing event: %v", err2)
 		}
 		gr.logf("%v: %v: failed: %v", id.String(), msg, flags["failed"])
+		rootSpan.Finish()
 	}(id)
 	err = gr.mc.BuildStarted(req.Build.GithubRepo, req.Build.Ref)
 	if err != nil {

--- a/lib/grpc/grpc.go
+++ b/lib/grpc/grpc.go
@@ -326,6 +326,7 @@ func (gr *GrpcServer) syncBuild(ctx context.Context, req *lib.BuildRequest) (out
 		} else {
 			eet = lib.BuildEventError_NO_ERROR
 			gr.mc.BuildSucceeded(req.Build.GithubRepo, req.Build.Ref)
+			rootSpan.Finish()
 		}
 		if err := gr.totalDuration(ctx, req); err != nil {
 			gr.logger.Printf("error pushing total duration: %v", err)
@@ -357,7 +358,6 @@ func (gr *GrpcServer) syncBuild(ctx context.Context, req *lib.BuildRequest) (out
 			gr.logf("failBuild: error publishing event: %v", err2)
 		}
 		gr.logf("%v: %v: failed: %v", id.String(), msg, flags["failed"])
-		rootSpan.Finish()
 	}(id)
 	err = gr.mc.BuildStarted(req.Build.GithubRepo, req.Build.Ref)
 	if err != nil {


### PR DESCRIPTION
PR does 3 things
1. Avoid overlapping spans during furan push operation
2. Propagate error messages properly from failed docker build events
3. Only report errors that correspond to build failures to datadog apm. We do not want datadog apm to count things like "Build not necessary" as an error for a trace. 