### PR TITLE
datadog apm: extract spans from contexts and properly use defer for finishing spans

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -636,10 +636,9 @@
   version = "v1.4.2"
 
 [[projects]]
-  digest = "1:8e7e862affe62ca299b3c4acfb6bfcbc156a28f16592eca50aa81e46f3f8816f"
+  digest = "1:dfa85ea7e0f402e82727c055cec1a7dfc95ffa7754ba417f672876e4baf497db"
   name = "gopkg.in/DataDog/dd-trace-go.v1"
   packages = [
-    "contrib/gocql/gocql",
     "contrib/google.golang.org/grpc.v12",
     "contrib/google.golang.org/internal/grpcutil",
     "ddtrace",
@@ -648,8 +647,8 @@
     "ddtrace/tracer",
   ]
   pruneopts = ""
-  revision = "823d51722f66a748804943f6fa6be18776073b82"
-  version = "v1.9.0"
+  revision = "fd9dc1465a7f279ce06639563428b56b01c3b146"
+  version = "v1.10.0"
 
 [[projects]]
   digest = "1:e5d1fb981765b6f7513f793a3fcaac7158408cca77f75f7311ac82cc88e9c445"
@@ -693,9 +692,7 @@
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/metadata",
-    "gopkg.in/DataDog/dd-trace-go.v1/contrib/gocql/gocql",
     "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc.v12",
-    "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext",
     "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,4 +67,4 @@
 
 [[constraint]]
   name = "gopkg.in/DataDog/dd-trace-go.v1"
-  version = "1.0.0"
+  version = "1.10.0"

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -235,7 +235,9 @@ func (ib *ImageBuilder) tagCheck(ctx context.Context, req *lib.BuildRequest) (bo
 		return true, nil
 	}
 	tagCheckSpan, ctx := tracer.StartSpanFromContext(ctx, "image_builder.tag_check")
-	defer tagCheckSpan.Finish(tracer.WithError(err))
+	defer func() {
+		tagCheckSpan.Finish(tracer.WithError(err))
+	}()
 	csha, err := ib.getCommitSHA(ctx, req.Build.GithubRepo, req.Build.Ref)
 	if err != nil {
 		return false, fmt.Errorf("error getting latest commit SHA: %v", err)
@@ -393,7 +395,9 @@ func (ib *ImageBuilder) dobuild(ctx context.Context, req *lib.BuildRequest, rbi 
 		BuildArgs:   req.Build.Args,
 	}
 	buildSpan, ctx := tracer.StartSpanFromContext(ctx, "image_builder.dobuild")
-	defer buildSpan.Finish(tracer.WithError(err))
+	defer func() {
+		buildSpan.Finish(tracer.WithError(err))
+	}()
 	ibr, err := ib.c.ImageBuild(ctx, rbi.Context, opts)
 	if err != nil {
 		dockerBuildStartError := pkgerror.Wrapf(err, "error starting build: ")
@@ -537,7 +541,9 @@ func (ib *ImageBuilder) CleanImage(ctx context.Context, imageid string) (err err
 		return fmt.Errorf("build id missing from context")
 	}
 	cleanSpan, _ := tracer.StartSpanFromContext(ctx, "image_builder.clean")
-	defer cleanSpan.Finish(tracer.WithError(err))
+	defer func() {
+		cleanSpan.Finish(tracer.WithError(err))
+	}()
 	ib.logf(ctx, "cleaning up images")
 	err = ib.dl.SetBuildTimeMetric(cleanSpan, id, "clean_started")
 	if err != nil {
@@ -659,7 +665,9 @@ func (ib *ImageBuilder) PushBuildToS3(ctx context.Context, imageid string, req *
 		return err
 	}
 	pushSpan, _ := tracer.StartSpanFromContext(ctx, "image_builder.push")
-	defer pushSpan.Finish(tracer.WithError(err))
+	defer func() {
+		pushSpan.Finish(tracer.WithError(err))
+	}()
 	info, _, err := ib.c.ImageInspectWithRaw(ctx, imageid)
 	if err != nil {
 		return err

--- a/lib/datalayer/datalayer.go
+++ b/lib/datalayer/datalayer.go
@@ -38,7 +38,9 @@ func NewDBLayer(s *gocql.Session) *DBLayer {
 // CreateBuild inserts a new build into the DB returning the ID
 func (dl *DBLayer) CreateBuild(parentSpan tracer.Span, req *lib.BuildRequest) (id gocql.UUID, err error) {
 	span := tracer.StartSpan("datalayer.create.build", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	q := `INSERT INTO builds_by_id (id, request, state, finished, failed, cancelled, started)
         VALUES (?,{github_repo: ?, dockerfile_path: ?, tags: ?, tag_with_commit_sha: ?, ref: ?,
 					push_registry_repo: ?, push_s3_region: ?, push_s3_bucket: ?,
@@ -66,7 +68,9 @@ func (dl *DBLayer) CreateBuild(parentSpan tracer.Span, req *lib.BuildRequest) (i
 // GetBuildByID fetches a build object from the DB
 func (dl *DBLayer) GetBuildByID(parentSpan tracer.Span, id gocql.UUID) (bi *lib.BuildStatusResponse, err error) {
 	span := tracer.StartSpan("datalayer.get.build.by.id", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	q := `SELECT request, state, finished, failed, cancelled, started, completed,
 	      duration FROM builds_by_id WHERE id = ?;`
 	var udt db.BuildRequestUDT
@@ -91,7 +95,9 @@ func (dl *DBLayer) GetBuildByID(parentSpan tracer.Span, id gocql.UUID) (bi *lib.
 // Caller must ensure that the flags passed in are valid
 func (dl *DBLayer) SetBuildFlags(parentSpan tracer.Span, id gocql.UUID, flags map[string]bool) (err error) {
 	span := tracer.StartSpan("datalayer.set_build_flags", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	q := `UPDATE builds_by_id SET %v = ? WHERE id = ?;`
 	for k, v := range flags {
 		err = dl.s.Query(fmt.Sprintf(q, k), v, id).Exec()
@@ -105,7 +111,9 @@ func (dl *DBLayer) SetBuildFlags(parentSpan tracer.Span, id gocql.UUID, flags ma
 // SetBuildCompletedTimestamp sets the completed timestamp on a build to time.Now()
 func (dl *DBLayer) SetBuildCompletedTimestamp(parentSpan tracer.Span, id gocql.UUID) (err error) {
 	span := tracer.StartSpan("datalayer.set_build_completed_timestamp", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	var started time.Time
 	now := time.Now()
 	q := `SELECT started FROM builds_by_id WHERE id = ?;`
@@ -121,7 +129,9 @@ func (dl *DBLayer) SetBuildCompletedTimestamp(parentSpan tracer.Span, id gocql.U
 // SetBuildState sets the state of a build
 func (dl *DBLayer) SetBuildState(parentSpan tracer.Span, id gocql.UUID, state lib.BuildStatusResponse_BuildState) (err error) {
 	span := tracer.StartSpan("datalayer.set_build_state", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	q := `UPDATE builds_by_id SET state = ? WHERE id = ?;`
 	return dl.s.Query(q, state.String(), id).Exec()
 }
@@ -130,7 +140,9 @@ func (dl *DBLayer) SetBuildState(parentSpan tracer.Span, id gocql.UUID, state li
 // Only used in case of queue full when we can't actually do a build
 func (dl *DBLayer) DeleteBuild(parentSpan tracer.Span, id gocql.UUID) (err error) {
 	span := tracer.StartSpan("datalayer.delete_build", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	q := `DELETE FROM builds_by_id WHERE id = ?;`
 	err = dl.s.Query(q, id).Exec()
 	if err != nil {
@@ -145,7 +157,9 @@ func (dl *DBLayer) DeleteBuild(parentSpan tracer.Span, id gocql.UUID) (err error
 // if metric is a *_completed column, it will also compute and persist the duration
 func (dl *DBLayer) SetBuildTimeMetric(parentSpan tracer.Span, id gocql.UUID, metric string) (err error) {
 	span := tracer.StartSpan("datalayer.set_build_time_metric", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	var started time.Time
 	now := time.Now()
 	getstarted := true
@@ -186,7 +200,9 @@ func (dl *DBLayer) SetBuildTimeMetric(parentSpan tracer.Span, id gocql.UUID, met
 // SetDockerImageSizesMetric sets the docker image sizes for a build
 func (dl *DBLayer) SetDockerImageSizesMetric(parentSpan tracer.Span, id gocql.UUID, size int64, vsize int64) (err error) {
 	span := tracer.StartSpan("datalayer.set_docker_image_size_metric", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	q := `UPDATE build_metrics_by_id SET docker_image_size = ?, docker_image_vsize = ? WHERE id = ?;`
 	return dl.s.Query(q, size, vsize, id).Exec()
 }
@@ -194,7 +210,9 @@ func (dl *DBLayer) SetDockerImageSizesMetric(parentSpan tracer.Span, id gocql.UU
 // SaveBuildOutput serializes an array of stream events to the database
 func (dl *DBLayer) SaveBuildOutput(parentSpan tracer.Span, id gocql.UUID, output []lib.BuildEvent, column string) (err error) {
 	span := tracer.StartSpan("datalayer.save_build_output", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	serialized := make([][]byte, len(output))
 	var b []byte
 	for i, e := range output {
@@ -211,7 +229,9 @@ func (dl *DBLayer) SaveBuildOutput(parentSpan tracer.Span, id gocql.UUID, output
 // GetBuildOutput returns an array of stream events from the database
 func (dl *DBLayer) GetBuildOutput(parentSpan tracer.Span, id gocql.UUID, column string) (output []lib.BuildEvent, err error) {
 	span := tracer.StartSpan("datalayer.get_build_output", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	var rawoutput [][]byte
 	output = []lib.BuildEvent{}
 	q := `SELECT %v FROM build_events_by_id WHERE id = ?;`

--- a/lib/github_fetch/github_fetch.go
+++ b/lib/github_fetch/github_fetch.go
@@ -48,7 +48,9 @@ func NewGitHubFetcher(token string) *GitHubFetcher {
 // GetCommitSHA returns the commit SHA for a reference
 func (gf *GitHubFetcher) GetCommitSHA(parentSpan tracer.Span, owner string, repo string, ref string) (csha string, err error) {
 	span := tracer.StartSpan("github_fetcher.get_commit_sha", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	ctx, cf := context.WithTimeout(context.Background(), githubDownloadTimeoutSecs*time.Second)
 	defer cf()
 	csha, _, err = gf.c.Repositories.GetCommitSHA1(ctx, owner, repo, ref, "")
@@ -59,7 +61,9 @@ func (gf *GitHubFetcher) GetCommitSHA(parentSpan tracer.Span, owner string, repo
 // an in-memory io.Reader.
 func (gf *GitHubFetcher) Get(parentSpan tracer.Span, owner string, repo string, ref string) (tarball io.Reader, err error) {
 	span := tracer.StartSpan("github_fetcher.get", tracer.ChildOf(parentSpan.Context()))
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	opt := &github.RepositoryContentGetOptions{
 		Ref: ref,
 	}

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/README.md
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/README.md
@@ -7,6 +7,8 @@ them to be used as they normally would with tracing activated out of the box.
 
 All of these libraries are supported by our [APM product](https://www.datadoghq.com/apm/).
 
+:warning: These libraries are not built to be used with Opentracing. Opentracing integrations can be found in [their own organisation](https://github.com/opentracing-contrib/).
+
 ### Usage
 
 First, find the library which you'd like to integrate with. The naming convention for the integration packages is:

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -20,6 +21,9 @@ import (
 type Client struct {
 	*redis.Client
 	*params
+
+	mu  sync.RWMutex // guards ctx
+	ctx context.Context
 }
 
 var _ redis.Cmdable = (*Client)(nil)
@@ -28,6 +32,8 @@ var _ redis.Cmdable = (*Client)(nil)
 type Pipeliner struct {
 	redis.Pipeliner
 	*params
+
+	ctx context.Context
 }
 
 var _ redis.Pipeliner = (*Pipeliner)(nil)
@@ -65,14 +71,17 @@ func WrapClient(c *redis.Client, opts ...ClientOption) *Client {
 		db:     strconv.Itoa(opt.DB),
 		config: cfg,
 	}
-	tc := &Client{c, params}
+	tc := &Client{Client: c, params: params}
 	tc.Client.WrapProcess(createWrapperFromClient(tc))
 	return tc
 }
 
 // Pipeline creates a Pipeline from a Client
 func (c *Client) Pipeline() redis.Pipeliner {
-	return &Pipeliner{c.Client.Pipeline(), c.params}
+	c.mu.RLock()
+	ctx := c.ctx
+	c.mu.RUnlock()
+	return &Pipeliner{c.Client.Pipeline(), c.params, ctx}
 }
 
 // ExecWithContext calls Pipeline.Exec(). It ensures that the resulting Redis calls
@@ -83,7 +92,7 @@ func (c *Pipeliner) ExecWithContext(ctx context.Context) ([]redis.Cmder, error) 
 
 // Exec calls Pipeline.Exec() ensuring that the resulting Redis calls are traced.
 func (c *Pipeliner) Exec() ([]redis.Cmder, error) {
-	return c.execWithContext(context.Background())
+	return c.execWithContext(c.ctx)
 }
 
 func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) {
@@ -120,8 +129,18 @@ func commandsToString(cmds []redis.Cmder) string {
 
 // WithContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent.
 func (c *Client) WithContext(ctx context.Context) *Client {
-	c.Client = c.Client.WithContext(ctx)
+	c.mu.Lock()
+	c.ctx = ctx
+	c.mu.Unlock()
 	return c
+}
+
+// Context returns the active context in the client.
+func (c *Client) Context() context.Context {
+	c.mu.RLock()
+	ctx := c.ctx
+	c.mu.RUnlock()
+	return ctx
 }
 
 // createWrapperFromClient returns a new createWrapper function which wraps the processor with tracing
@@ -130,7 +149,9 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 		return func(cmd redis.Cmder) error {
-			ctx := tc.Client.Context()
+			tc.mu.RLock()
+			ctx := tc.ctx
+			tc.mu.RUnlock()
 			raw := cmderToString(cmd)
 			parts := strings.Split(raw, " ")
 			length := len(parts) - 1

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(m.Run())
 }
+
 func TestClientEvalSha(t *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
 	assert := assert.New(t)
@@ -48,6 +50,27 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 	assert.Equal("6379", span.Tag(ext.TargetPort))
 	assert.Equal("evalsha", span.Tag(ext.ResourceName))
+}
+
+// https://github.com/DataDog/dd-trace-go/issues/387
+func TestIssue387(t *testing.T) {
+	opts := &redis.Options{Addr: "127.0.0.1:6379"}
+	client := NewClient(opts, WithServiceName("my-redis"))
+	n := 1000
+
+	client.Set("test_key", "test_value", 0)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			client.WithContext(context.Background()).Get("test_key").Result()
+		}()
+	}
+	wg.Wait()
+
+	// should not result in a race
 }
 
 func TestClient(t *testing.T) {

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/client.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/client.go
@@ -26,7 +26,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err, cs.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
 	}
 	err = cs.ClientStream.RecvMsg(m)
 	return err
@@ -38,7 +38,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err, cs.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
 	}
 	err = cs.ClientStream.SendMsg(m)
 	return err

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/grpc.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/grpc.go
@@ -33,8 +33,11 @@ func startSpanFromContext(ctx context.Context, method, operation, service string
 
 // finishWithError applies finish option and a tag with gRPC status code, disregarding OK, EOF and Canceled errors.
 func finishWithError(span ddtrace.Span, err error, noDebugStack bool) {
+	if err == io.EOF || err == context.Canceled {
+		err = nil
+	}
 	errcode := status.Code(err)
-	if err == io.EOF || errcode == codes.Canceled || errcode == codes.OK || err == context.Canceled {
+	if errcode == codes.Canceled || errcode == codes.OK {
 		err = nil
 	}
 	span.SetTag(tagCode, errcode.String())

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/server.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/server.go
@@ -28,7 +28,7 @@ func (ss *serverStream) Context() context.Context {
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err, ss.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.RecvMsg(m)
 	return err
@@ -37,7 +37,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err, ss.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.SendMsg(m)
 	return err
@@ -60,7 +60,7 @@ func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterce
 		if cfg.traceStreamCalls {
 			var span ddtrace.Span
 			span, ctx = startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serviceName)
-			defer finishWithError(span, err, cfg.noDebugStack)
+			defer func() { finishWithError(span, err, cfg.noDebugStack) }()
 		}
 
 		// call the original handler with a new stream, which traces each send

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo.go
@@ -1,4 +1,5 @@
 // Package mongo provides functions to trace the mongodb/mongo-go-driver package (https://github.com/mongodb/mongo-go-driver).
+// It support v0.2.0 of github.com/mongodb/mongo-go-driver
 //
 // `NewMonitor` will return an event.CommandMonitor which is used to trace requests.
 package mongo

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
@@ -60,7 +60,7 @@ func Test(t *testing.T) {
 	assert.Equal(t, "mongo.insert", s.Tag(ext.ResourceName))
 	assert.Equal(t, hostname, s.Tag(ext.PeerHostname))
 	assert.Equal(t, port, s.Tag(ext.PeerPort))
-	assert.Contains(t, s.Tag(ext.DBStatement), `{"insert":"test-collection","ordered":true,"$db":"test-database","documents":[{"_id":{"`)
+	assert.Contains(t, s.Tag(ext.DBStatement), `"test-item":"test-value"`)
 	assert.Equal(t, "test-database", s.Tag(ext.DBInstance))
 	assert.Equal(t, "mongo", s.Tag(ext.DBType))
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ddtrace.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ddtrace.go
@@ -108,4 +108,8 @@ type StartSpanConfig struct {
 	// Tags holds a set of key/value pairs that should be set as metadata on the
 	// new span.
 	Tags map[string]interface{}
+
+	// Force-set the SpanID, rather than use a random number. If no Parent SpanContext is present,
+	// then this will also set the TraceID to the same value.
+	SpanID uint64
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/option.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/option.go
@@ -149,6 +149,15 @@ func SpanType(name string) StartSpanOption {
 	return Tag(ext.SpanType, name)
 }
 
+// WithSpanID sets the SpanID on the started span, instead of using a random number.
+// If there is no parent Span (eg from ChildOf), then the TraceID will also be set to the
+// value given here.
+func WithSpanID(id uint64) StartSpanOption {
+	return func(cfg *ddtrace.StartSpanConfig) {
+		cfg.SpanID = id
+	}
+}
+
 // ChildOf tells StartSpan to use the given span context as a parent for the
 // created span.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {
@@ -179,7 +188,8 @@ func FinishTime(t time.Time) FinishOption {
 }
 
 // WithError marks the span as having had an error. It uses the information from
-// err to set tags such as the error message, error type and stack trace.
+// err to set tags such as the error message, error type and stack trace. It has
+// no effect if the error is nil.
 func WithError(err error) FinishOption {
 	return func(cfg *ddtrace.FinishConfig) {
 		cfg.Error = err

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler.go
@@ -140,5 +140,5 @@ func (ps *prioritySampler) apply(spn *span) {
 	} else {
 		spn.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
 	}
-	spn.SetTag(samplingPriorityRateKey, rate)
+	spn.SetTag(keySamplingPriorityRate, rate)
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler_test.go
@@ -144,18 +144,18 @@ func TestPrioritySampler(t *testing.T) {
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 4)
 
 		ps.apply(testSpan1)
-		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 3)
 		ps.apply(testSpan1)
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.Service = "other-service"
 		testSpan1.TraceID = 1
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 	})
 }
 

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span.go
@@ -150,7 +150,7 @@ func (s *span) setTagNumeric(key string, v float64) {
 	switch key {
 	case ext.SamplingPriority:
 		// setting sampling priority per spec
-		s.Metrics[samplingPriorityKey] = v
+		s.Metrics[keySamplingPriority] = v
 		s.context.setSamplingPriority(int(v))
 	default:
 		s.Metrics[key] = v
@@ -236,6 +236,7 @@ func (s *span) String() string {
 }
 
 const (
-	samplingPriorityKey     = "_sampling_priority_v1"
-	samplingPriorityRateKey = "_sampling_priority_rate_v1"
+	keySamplingPriority     = "_sampling_priority_v1"
+	keySamplingPriorityRate = "_sampling_priority_rate_v1"
+	keyOrigin               = "_dd.origin"
 )

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span_test.go
@@ -160,7 +160,7 @@ func TestSpanSetTag(t *testing.T) {
 	assert.Equal(int32(0), span.Error)
 
 	span.SetTag(ext.SamplingPriority, 2)
-	assert.Equal(float64(2), span.Metrics[samplingPriorityKey])
+	assert.Equal(float64(2), span.Metrics[keySamplingPriority])
 }
 
 func TestSpanSetDatadogTags(t *testing.T) {
@@ -204,9 +204,9 @@ func TestSpanSetMetric(t *testing.T) {
 	span.SetTag("bytes", 1024.42)
 	assert.Equal(3, len(span.Metrics))
 	assert.Equal(1024.42, span.Metrics["bytes"])
-	_, ok := span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[keySamplingPriority]
 	assert.True(ok)
-	_, ok = span.Metrics[samplingPriorityRateKey]
+	_, ok = span.Metrics[keySamplingPriorityRate]
 	assert.True(ok)
 
 	// operating on a finished span is a no-op
@@ -301,9 +301,9 @@ func TestSpanSamplingPriority(t *testing.T) {
 	tracer := newTracer(withTransport(newDefaultTransport()))
 
 	span := tracer.newRootSpan("my.name", "my.service", "my.resource")
-	_, ok := span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[keySamplingPriority]
 	assert.True(ok)
-	_, ok = span.Metrics[samplingPriorityRateKey]
+	_, ok = span.Metrics[keySamplingPriorityRate]
 	assert.True(ok)
 
 	for _, priority := range []int{
@@ -314,15 +314,15 @@ func TestSpanSamplingPriority(t *testing.T) {
 		999, // not used, but we should allow it
 	} {
 		span.SetTag(ext.SamplingPriority, priority)
-		v, ok := span.Metrics[samplingPriorityKey]
+		v, ok := span.Metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.EqualValues(priority, v)
 		assert.EqualValues(span.context.priority, v)
 		assert.True(span.context.hasPriority)
 
 		childSpan := tracer.newChildSpan("my.child", span)
-		v0, ok0 := span.Metrics[samplingPriorityKey]
-		v1, ok1 := childSpan.Metrics[samplingPriorityKey]
+		v0, ok0 := span.Metrics[keySamplingPriority]
+		v1, ok1 := childSpan.Metrics[keySamplingPriority]
 		assert.Equal(ok0, ok1)
 		assert.Equal(v0, v1)
 		assert.EqualValues(childSpan.context.priority, v0)

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext.go
@@ -28,6 +28,7 @@ type spanContext struct {
 	mu          sync.RWMutex // guards below fields
 	baggage     map[string]string
 	priority    int
+	origin      string // e.g. "synthetics"
 	hasPriority bool
 }
 
@@ -42,7 +43,7 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		spanID:  span.SpanID,
 		span:    span,
 	}
-	if v, ok := span.Metrics[samplingPriorityKey]; ok {
+	if v, ok := span.Metrics[keySamplingPriority]; ok {
 		context.hasPriority = true
 		context.priority = int(v)
 	}
@@ -51,6 +52,7 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		context.drop = parent.drop
 		context.hasPriority = parent.hasSamplingPriority()
 		context.priority = parent.samplingPriority()
+		context.origin = parent.origin
 		parent.ForeachBaggageItem(func(k, v string) bool {
 			context.setBaggageItem(k, v)
 			return true

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext_test.go
@@ -171,7 +171,7 @@ func TestNewSpanContext(t *testing.T) {
 			TraceID:  1,
 			SpanID:   2,
 			ParentID: 3,
-			Metrics:  map[string]float64{samplingPriorityKey: 1},
+			Metrics:  map[string]float64{keySamplingPriority: 1},
 		}
 		ctx := newSpanContext(span, nil)
 		assert := assert.New(t)
@@ -207,6 +207,10 @@ func TestSpanContextParent(t *testing.T) {
 			hasPriority: true,
 			priority:    2,
 		},
+		"origin": &spanContext{
+			trace:  &trace{spans: []*span{newBasicSpan("abc")}},
+			origin: "synthetics",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := newSpanContext(s, parentCtx)
@@ -222,6 +226,7 @@ func TestSpanContextParent(t *testing.T) {
 			assert.Equal(ctx.priority, parentCtx.priority)
 			assert.Equal(ctx.drop, parentCtx.drop)
 			assert.Equal(ctx.baggage, parentCtx.baggage)
+			assert.Equal(ctx.origin, parentCtx.origin)
 		})
 	}
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer.go
@@ -230,7 +230,10 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			context = ctx
 		}
 	}
-	id := random.Uint64()
+	id := opts.SpanID
+	if id == 0 {
+		id = random.Uint64()
+	}
 	// span defaults
 	span := &span{
 		Name:     operationName,
@@ -248,13 +251,19 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.TraceID = context.traceID
 		span.ParentID = context.spanID
 		if context.hasSamplingPriority() {
-			span.Metrics[samplingPriorityKey] = float64(context.samplingPriority())
+			span.Metrics[keySamplingPriority] = float64(context.samplingPriority())
 		}
 		if context.span != nil {
-			// it has a local parent, inherit the service
+			// local parent, inherit service
 			context.span.RLock()
 			span.Service = context.span.Service
 			context.span.RUnlock()
+		} else {
+			// remote parent
+			if context.origin != "" {
+				// mark origin
+				span.Meta[keyOrigin] = context.origin
+			}
 		}
 	}
 	span.context = newSpanContext(span, context)

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer_test.go
@@ -165,13 +165,13 @@ func TestTracerStartSpan(t *testing.T) {
 		assert.Contains([]float64{
 			ext.PriorityAutoReject,
 			ext.PriorityAutoKeep,
-		}, span.Metrics[samplingPriorityKey])
+		}, span.Metrics[keySamplingPriority])
 	})
 
 	t.Run("priority", func(t *testing.T) {
 		tracer := newTracer()
 		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).(*span)
-		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[samplingPriorityKey])
+		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[keySamplingPriority])
 	})
 }
 
@@ -183,6 +183,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 		ServiceName("test.service"),
 		ResourceName("test.resource"),
 		StartTime(now),
+		WithSpanID(420),
 	}
 	span := tracer.StartSpan("web.request", opts...).(*span)
 	assert := assert.New(t)
@@ -190,6 +191,8 @@ func TestTracerStartSpanOptions(t *testing.T) {
 	assert.Equal("test.service", span.Service)
 	assert.Equal("test.resource", span.Resource)
 	assert.Equal(now.UnixNano(), span.Start)
+	assert.Equal(uint64(420), span.SpanID)
+	assert.Equal(uint64(420), span.TraceID)
 }
 
 func TestTracerStartChildSpan(t *testing.T) {
@@ -197,12 +200,17 @@ func TestTracerStartChildSpan(t *testing.T) {
 		assert := assert.New(t)
 		tracer := newTracer()
 		root := tracer.StartSpan("web.request", ServiceName("root-service")).(*span)
-		child := tracer.StartSpan("db.query", ChildOf(root.Context()), ServiceName("child-service")).(*span)
+		child := tracer.StartSpan("db.query",
+			ChildOf(root.Context()),
+			ServiceName("child-service"),
+			WithSpanID(69)).(*span)
 
 		assert.NotEqual(uint64(0), child.TraceID)
 		assert.NotEqual(uint64(0), child.SpanID)
 		assert.Equal(root.SpanID, child.ParentID)
 		assert.Equal(root.TraceID, child.ParentID)
+		assert.Equal(root.TraceID, child.TraceID)
+		assert.Equal(uint64(69), child.SpanID)
 		assert.Equal("child-service", child.Service)
 	})
 
@@ -225,6 +233,34 @@ func TestTracerBaggagePropagation(t *testing.T) {
 	context := child.Context().(*spanContext)
 
 	assert.Equal("value", context.baggage["key"])
+}
+
+func TestStartSpanOrigin(t *testing.T) {
+	assert := assert.New(t)
+
+	tracer := newTracer()
+
+	carrier := TextMapCarrier(map[string]string{
+		DefaultTraceIDHeader:  "1",
+		DefaultParentIDHeader: "1",
+		originHeader:          "synthetics",
+	})
+	ctx, err := tracer.Extract(carrier)
+	assert.Nil(err)
+
+	// first child contains tag
+	child := tracer.StartSpan("child", ChildOf(ctx))
+	assert.Equal("synthetics", child.(*span).Meta[keyOrigin])
+
+	// secondary child doesn't
+	child2 := tracer.StartSpan("child2", ChildOf(child.Context()))
+	assert.Empty(child2.(*span).Meta[keyOrigin])
+
+	// but injecting its context marks origin
+	carrier2 := TextMapCarrier(map[string]string{})
+	err = tracer.Inject(child2.Context(), carrier2)
+	assert.Nil(err)
+	assert.Equal("synthetics", carrier2[originHeader])
 }
 
 func TestPropagationDefaults(t *testing.T) {
@@ -278,8 +314,8 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	tracer := newTracer()
 	root := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, 2)).(*span)
 	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
-	assert.EqualValues(2, root.Metrics[samplingPriorityKey])
-	assert.EqualValues(2, child.Metrics[samplingPriorityKey])
+	assert.EqualValues(2, root.Metrics[keySamplingPriority])
+	assert.EqualValues(2, child.Metrics[keySamplingPriority])
 	assert.EqualValues(2, root.context.priority)
 	assert.EqualValues(2, child.context.priority)
 	assert.True(root.context.hasPriority)
@@ -403,10 +439,10 @@ func TestTracerPrioritySampler(t *testing.T) {
 
 	// default rates (1.0)
 	s := tr.newEnvSpan("pylons", "")
-	assert.Equal(1., s.Metrics[samplingPriorityRateKey])
-	assert.Equal(1., s.Metrics[samplingPriorityKey])
+	assert.Equal(1., s.Metrics[keySamplingPriorityRate])
+	assert.Equal(1., s.Metrics[keySamplingPriority])
 	assert.True(s.context.hasSamplingPriority())
-	assert.EqualValues(s.context.samplingPriority(), s.Metrics[samplingPriorityKey])
+	assert.EqualValues(s.context.samplingPriority(), s.Metrics[keySamplingPriority])
 	s.Finish()
 
 	tr.forceFlush() // obtain new rates
@@ -435,8 +471,8 @@ func TestTracerPrioritySampler(t *testing.T) {
 		},
 	} {
 		s := tr.newEnvSpan(tt.service, tt.env)
-		assert.Equal(tt.rate, s.Metrics[samplingPriorityRateKey], strconv.Itoa(i))
-		prio, ok := s.Metrics[samplingPriorityKey]
+		assert.Equal(tt.rate, s.Metrics[keySamplingPriorityRate], strconv.Itoa(i))
+		prio, ok := s.Metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.Contains([]float64{0, 1}, prio)
 		assert.True(s.context.hasSamplingPriority())

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/transport.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/transport.go
@@ -15,7 +15,7 @@ import (
 var (
 	// TODO(gbbr): find a more effective way to keep this up to date,
 	// e.g. via `go generate`
-	tracerVersion = "v1.7.0"
+	tracerVersion = "v1.10.0"
 
 	// We copy the transport to avoid using the default one, as it might be
 	// augmented with tracing and we don't want these calls to be recorded.


### PR DESCRIPTION
Commits 1 - 4: Extract parent spans from contexts when applicable and get rid of extraneous spans
Commit 5: Upgrade datadog apm go package to enable priority scheduling by default (required for distributed tracing)
Commit 6: Fix issue with incorrect usage of `defer` that I introduced when initially setting up datadog apm. 