### PR TITLE
issue 73: label cancelled builds as user error

### DIFF
--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -293,7 +293,7 @@ func (ib *ImageBuilder) Build(ctx context.Context, req *lib.BuildRequest, id goc
 	owner := rl[0]
 	repo := rl[1]
 	if buildcontext.IsCancelled(ctx.Done()) {
-		return "", fmt.Errorf("build was cancelled: %v", ctx.Err())
+		return "", errors.UserError(fmt.Sprintf("build was cancelled: %v", ctx.Err()))
 	}
 	ib.logf(ctx, "fetching github repo: %v", req.Build.GithubRepo)
 	contents, err := ib.gf.Get(parentSpan, owner, repo, req.Build.Ref)
@@ -321,7 +321,7 @@ func (ib *ImageBuilder) Build(ctx context.Context, req *lib.BuildRequest, id goc
 
 func (ib *ImageBuilder) saveOutput(ctx context.Context, action actionType, events []lib.BuildEvent) error {
 	if buildcontext.IsCancelled(ctx.Done()) {
-		return fmt.Errorf("build was cancelled: %v", ctx.Err())
+		return errors.UserError(fmt.Sprintf("build was cancelled: %v", ctx.Err()))
 	}
 	id, ok := buildcontext.BuildIDFromContext(ctx)
 	if !ok {
@@ -376,9 +376,6 @@ const (
 // doBuild executes the archive file GET and triggers the Docker build
 func (ib *ImageBuilder) dobuild(ctx context.Context, req *lib.BuildRequest, rbi *RepoBuildData) (_ string, err error) {
 	var imageid string
-	if buildcontext.IsCancelled(ctx.Done()) {
-		return imageid, fmt.Errorf("build was cancelled: %v", ctx.Err())
-	}
 	id, ok := buildcontext.BuildIDFromContext(ctx)
 	if !ok {
 		return imageid, fmt.Errorf("build id missing from context")
@@ -399,6 +396,9 @@ func (ib *ImageBuilder) dobuild(ctx context.Context, req *lib.BuildRequest, rbi 
 	}()
 	ibr, err := ib.c.ImageBuild(ctx, rbi.Context, opts)
 	if err != nil {
+		if buildcontext.IsCancelled(ctx.Done()) {
+			return imageid, errors.UserError(fmt.Sprintf("build was cancelled: %v", ctx.Err()))
+		}
 		dockerBuildStartError := pkgerror.Wrapf(err, "error starting build: ")
 		if strings.HasPrefix(err.Error(), malformedDockerfileEventPrefix) {
 			dockerBuildStartError = errors.UserError(fmt.Sprintf("malformed dockerfile: %v", err))
@@ -408,8 +408,11 @@ func (ib *ImageBuilder) dobuild(ctx context.Context, req *lib.BuildRequest, rbi 
 	output, err := ib.monitorDockerAction(ctx, ibr.Body, Build)
 	err2 := ib.saveOutput(ctx, Build, output) // we want to save output even if error
 	if err != nil {
+		if buildcontext.IsCancelled(ctx.Done()) {
+			return imageid, errors.UserError(fmt.Sprintf("build was cancelled: %v", ctx.Err()))
+		}
 		le := output[len(output)-1]
-		dockerBuildError := fmt.Errorf("build failed: %v, %(v) ", err, le.Message)
+		dockerBuildError := fmt.Errorf("build failed: %v, (%v) ", err, le.Message)
 		if le.EventError.ErrorType == lib.BuildEventError_FATAL && ib.s3errorcfg.PushToS3 {
 			ib.logf(ctx, "pushing failed build log to S3: %v", id.String())
 			loc, err3 := ib.saveEventLogToS3(ctx, req.Build.GithubRepo, req.Build.Ref, Build, output)
@@ -453,7 +456,7 @@ func (ib *ImageBuilder) dobuild(ctx context.Context, req *lib.BuildRequest, rbi 
 
 func (ib *ImageBuilder) writeDockerImageSizeMetrics(ctx context.Context, imageid string, repo string, ref string) error {
 	if buildcontext.IsCancelled(ctx.Done()) {
-		return fmt.Errorf("build was cancelled: %v", ctx.Err())
+		return errors.UserError(fmt.Sprintf("build was cancelled: %v", ctx.Err()))
 	}
 	id, ok := buildcontext.BuildIDFromContext(ctx)
 	if !ok {
@@ -495,10 +498,10 @@ func (ib *ImageBuilder) monitorDockerAction(ctx context.Context, rc io.ReadClose
 	output := []lib.BuildEvent{}
 	var bevent *lib.BuildEvent
 	for {
-		if buildcontext.IsCancelled(ctx.Done()) {
-			return output, fmt.Errorf("action was cancelled: %v", ctx.Err())
-		}
 		line, err := rdr.ReadBytes('\n')
+		if buildcontext.IsCancelled(ctx.Done()) {
+			return output, errors.UserError(fmt.Sprintf("action was cancelled: %v", ctx.Err()))
+		}
 		if err != nil {
 			if err == io.EOF {
 				return output, nil
@@ -532,7 +535,7 @@ func (ib *ImageBuilder) monitorDockerAction(ctx context.Context, rc io.ReadClose
 // CleanImage cleans up the built image after it's been pushed
 func (ib *ImageBuilder) CleanImage(ctx context.Context, imageid string) (err error) {
 	if buildcontext.IsCancelled(ctx.Done()) {
-		return fmt.Errorf("clean was cancelled: %v", ctx.Err())
+		return errors.UserError(fmt.Sprintf("clean was cancelled: %v", ctx.Err()))
 	}
 	id, ok := buildcontext.BuildIDFromContext(ctx)
 	if !ok {
@@ -566,7 +569,7 @@ func (ib *ImageBuilder) CleanImage(ctx context.Context, imageid string) (err err
 // been built successfully
 func (ib *ImageBuilder) PushBuildToRegistry(ctx context.Context, req *lib.BuildRequest) (err error) {
 	if buildcontext.IsCancelled(ctx.Done()) {
-		return fmt.Errorf("push was cancelled: %v", ctx.Err())
+		return errors.UserError(fmt.Sprintf("push was cancelled: %v", ctx.Err()))
 	}
 	id, ok := buildcontext.BuildIDFromContext(ctx)
 	if !ok {
@@ -617,10 +620,10 @@ func (ib *ImageBuilder) PushBuildToRegistry(ctx context.Context, req *lib.BuildR
 		}
 	}()
 	for _, name := range inames {
-		if buildcontext.IsCancelled(ctx.Done()) {
-			return fmt.Errorf("push was cancelled: %v", ctx.Err())
-		}
 		ipr, err := ib.c.ImagePush(ctx, name, opts)
+		if buildcontext.IsCancelled(ctx.Done()) {
+			return errors.UserError(fmt.Sprintf("push was cancelled: %v", ctx.Err()))
+		}
 		if err != nil {
 			return fmt.Errorf("error initiating registry push: %v", err)
 		}
@@ -655,7 +658,7 @@ func (ib *ImageBuilder) getCommitSHA(ctx context.Context, repo, ref string) (str
 // PushBuildToS3 exports and uploads the already built image to the configured S3 bucket/key
 func (ib *ImageBuilder) PushBuildToS3(ctx context.Context, imageid string, req *lib.BuildRequest) (err error) {
 	if buildcontext.IsCancelled(ctx.Done()) {
-		return fmt.Errorf("push was cancelled: %v", ctx.Err())
+		return errors.UserError(fmt.Sprintf("push was cancelled: %v", ctx.Err()))
 	}
 	csha, err := ib.getCommitSHA(ctx, req.Build.GithubRepo, req.Build.Ref)
 	if err != nil {

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -1,19 +1,25 @@
 package errors
 
+import "github.com/pkg/errors"
+
 type user interface {
 	User() bool
 }
 
-// UserError is an error caused by invalid user input
+// UserError is an error caused by a user. This is supposed to represent both
+// unintentional errors (like invalid input) and intentional "errors" (like
+// cancellation).
 type UserError string
 
 // User returns true if the error is caused by the user
-func (e UserError) User() bool    { return true }
+func (e UserError) User() bool { return true }
+
+// Error stringifies the user error
 func (e UserError) Error() string { return "user error: " + string(e) }
 
 // IsUserError returns true if err is caused by the user
 func IsUserError(err error) bool {
-	e, ok := err.(user)
+	e, ok := errors.Cause(err).(user)
 	if ok {
 		return e.User()
 	}

--- a/lib/errors/errors_test.go
+++ b/lib/errors/errors_test.go
@@ -3,6 +3,8 @@ package errors
 import (
 	"fmt"
 	"testing"
+
+	pkgerrors "github.com/pkg/errors"
 )
 
 func TestUserErrorDetection(t *testing.T) {
@@ -17,6 +19,18 @@ func TestUserErrorDetection(t *testing.T) {
 		{
 			input:          UserError("you did this"),
 			expectedResult: true,
+		},
+		{
+			input:          pkgerrors.Wrap(UserError("you did this"), "some context"),
+			expectedResult: true,
+		},
+		{
+			input:          pkgerrors.Wrap(pkgerrors.Wrap(UserError("you did this"), "some context"), "more context"),
+			expectedResult: true,
+		},
+		{
+			input:          pkgerrors.Wrap(fmt.Errorf("not a user error"), "some context"),
+			expectedResult: false,
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
closes https://github.com/dollarshaveclub/furan/issues/73
**Summary**

- Allow `UserError` type to be wrapped and unwrapped properly
- Ensure that we check that the cancellation wasn't cancelled during IO operations in which it is likely to be cancelled. Then return a `UserError` so that we can not trigger alerts based off these cancellations. There are probably more occurrences of this that we may need to change in later PRs if we do run into those issues. 
- Start wrapping errors in the Build method so that we can preserve the root cause (in order to check if it is a user error). 