### PR TITLE
Properly set datadog service names

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -164,6 +164,7 @@ func build(cmd *cobra.Command, args []string) {
 	}
 
 	logger = log.New(dnull, "", log.LstdFlags)
+	datadogGrpcServiceName := datadogServiceName + ".grpc"
 	gs := grpc.NewGRPCServer(ib, dbConfig.Datalayer, kafkaConfig.Manager, kafkaConfig.Manager, mc, kvo, 1, 1, logger, datadogGrpcServiceName)
 
 	resp, err := gs.StartBuild(ctx, &cliBuildRequest)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,8 +38,6 @@ var awscredsprefix string
 var dogstatsdAddr string
 var defaultMetricsTags string
 var datadogServiceName string
-var datadogGrpcServiceName string
-var datadogCassandaServiceName string
 var datadogTracingAgentAddr string
 
 var logger *log.Logger
@@ -97,8 +95,6 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&defaultMetricsTags, "default-metrics-tags", "s", "env:qa", "Comma-delimited list of tag keys and values in the form key:value")
 	RootCmd.PersistentFlags().StringVarP(&datadogServiceName, "datadog-service-name", "w", "furan", "Datadog APM service name")
 	RootCmd.PersistentFlags().StringVarP(&datadogTracingAgentAddr, "datadog-tracing-agent-addr", "y", "127.0.0.1:8126", "Address of datadog tracing agent")
-	datadogGrpcServiceName = strings.Join([]string{datadogServiceName, "grpc"}, ".")
-	datadogCassandaServiceName = strings.Join([]string{datadogServiceName, "cassandra"}, ".")
 }
 
 func clierr(msg string, params ...interface{}) {
@@ -176,6 +172,7 @@ func setupDataLayer() {
 	if err != nil {
 		log.Fatalf("error creating DB session: %v", err)
 	}
+	datadogCassandaServiceName := datadogServiceName + ".cassandra"
 	dbConfig.Datalayer = datalayer.NewDBLayer(s, datadogCassandaServiceName)
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -170,6 +170,7 @@ func server(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("error creating key value orchestrator: %v", err)
 	}
+	datadogGrpcServiceName := datadogServiceName + ".grpc"
 	grpcSvr := grpc.NewGRPCServer(imageBuilder, dbConfig.Datalayer, kafkaConfig.Manager, kafkaConfig.Manager, mc, kvo, serverConfig.Queuesize, serverConfig.Concurrency, logger, datadogGrpcServiceName)
 	go grpcSvr.ListenRPC(serverConfig.GRPCAddr, serverConfig.GRPCPort)
 


### PR DESCRIPTION
Noticed during the last canary deployment that some of the datadog apm service names weren't being set properly. This resolves the issue. 