### PR TITLE
rpcclient: modify datadog service name configuration

### DIFF
--- a/rpcclient/rpcclient.go
+++ b/rpcclient/rpcclient.go
@@ -71,9 +71,9 @@ type furanNode struct {
 
 // NewFuranClient takes a Consul service name and returns a client which connects
 // to a randomly chosen Furan host and uses the optional logger
-func NewFuranClient(opts *DiscoveryOptions, logger *log.Logger, datadogServiceName string) (*FuranClient, error) {
+func NewFuranClient(opts *DiscoveryOptions, logger *log.Logger, datadogServiceNamePrefix string) (*FuranClient, error) {
 	fc := &FuranClient{}
-	fc.ddName = datadogServiceName
+	fc.ddName = datadogServiceNamePrefix + ".furan-client"
 	if logger == nil {
 		fc.logger = log.New(os.Stderr, "", log.LstdFlags)
 	} else {


### PR DESCRIPTION
We do not use the furan client within this repo, however, Acyl does use it. 

There are multiple spots where we have to call `NewFuranClient` within Acyl, mostly due to the Nitro feature flag. 

This patch allows us to have a simpler means of configuring the client. As opposed to having to keep track of a consistent datadog service name for the furan client specifically, we can just use the datadog service name prefix that is passed in as a command line argument to Acyl, and then let the furan client decide its service name suffix. 