### PR TITLE
helm: fix incorrect value name in chart template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib/testdata/*.tar.gz
 local_dev_secrets.local.json
 build
 releases
+.idea

--- a/.helm/charts/furan/templates/deployment.yaml
+++ b/.helm/charts/furan/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -146,4 +145,3 @@ spec:
             port: {{ .Values.service.httpHealthcheckPort }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-{{ end }}

--- a/.helm/charts/furan/templates/deployment.yaml
+++ b/.helm/charts/furan/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +22,7 @@ spec:
         app: {{ template "fullname" . }}
         appsel: furan
     spec:
-      {{ if .Values.vault.k8s_auth }}
+      {{ if .Values.vault.useK8sAuth }}
       serviceAccountName: {{ .Values.vault.serviceaccount }}
       {{ end }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -145,3 +146,4 @@ spec:
             port: {{ .Values.service.httpHealthcheckPort }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{ end }}

--- a/.helm/charts/furan/values.yaml
+++ b/.helm/charts/furan/values.yaml
@@ -4,7 +4,6 @@
 replicaCount: 8
 maxSurge: 25%
 maxUnavailable: 25%
-enabled: true
 image:
   repository: quay.io/dollarshaveclub/furan
   tag: master

--- a/.helm/charts/furan/values.yaml
+++ b/.helm/charts/furan/values.yaml
@@ -4,6 +4,7 @@
 replicaCount: 8
 maxSurge: 25%
 maxUnavailable: 25%
+enabled: true
 image:
   repository: quay.io/dollarshaveclub/furan
   tag: master


### PR DESCRIPTION
We previously replaced the `k8s_auth` value with `useK8sAuth`. This PR updates deployment manifest to use the correct value. 
