### PR TITLE
fix: scan request udt how gocql expects

### DIFF
--- a/lib/datalayer/datalayer.go
+++ b/lib/datalayer/datalayer.go
@@ -79,7 +79,8 @@ func (dl *DBLayer) GetBuildByID(ctx context.Context, id gocql.UUID) (bi *lib.Bui
 		BuildId: id.String(),
 	}
 	query := dl.s.Query(q, id)
-	err = dl.wrapQuery(ctx, query).Scan(&udt, &state, &bi.Finished, &bi.Failed,
+	err = dl.wrapQuery(ctx, query).Scan(&udt.GithubRepo, &udt.DockerfilePath, udt.Tags, udt.TagWithCommitSha, udt.Ref,
+		udt.PushRegistryRepo, udt.PushS3Region, udt.PushS3Bucket, udt.PushS3KeyPrefix, &state, &bi.Finished, &bi.Failed,
 		&bi.Cancelled, &started, &completed, &bi.Duration)
 	if err != nil {
 		return bi, err


### PR DESCRIPTION
With the current implementation, newer versions of scylladb seem to respond in a manner that makes gocql respond with the error: `not enough columns to scan into: have 8 want 16`. 

It appears that when we initially insert the data, we are scanning the values from each BuildRequest field individually. When we fetch the data, we should be scanning the values in the same manner. 