### PR TITLE
cmd: add monitoring around trigger cmd

### DIFF
--- a/cmd/cancel.go
+++ b/cmd/cancel.go
@@ -62,7 +62,7 @@ func cancel(cmd *cobra.Command, args []string) {
 
 	resp, err := c.CancelBuild(context.Background(), cancelReq)
 	if err != nil {
-		rpcerr(err, "CancelBuild")
+		rpcerr(err, "CancelBuild", nil)
 	}
 	log.Printf("%v\n", *resp)
 }

--- a/cmd/trigger.go
+++ b/cmd/trigger.go
@@ -104,7 +104,7 @@ func getFuranServerFromConsul(svc string) (*furanNode, error) {
 
 func triggerFailed(err error, mc metrics.MetricsCollector) {
 	if (mc != nil) {
-		mc.TriggerFailed(cliBuildRequest.Build.GithubRepo, cliBuildRequest.Build.Ref)
+		mc.TriggerCompleted(cliBuildRequest.Build.GithubRepo, cliBuildRequest.Build.Ref, true)
 	}
 	fmt.Fprintf(os.Stderr, "trigger failed: %v", err)
 	os.Exit(1)
@@ -112,7 +112,7 @@ func triggerFailed(err error, mc metrics.MetricsCollector) {
 
 func triggerSucceeded(mc metrics.MetricsCollector) {
 	if (mc != nil) {
-		mc.TriggerSucceeded(cliBuildRequest.Build.GithubRepo, cliBuildRequest.Build.Ref)
+		mc.TriggerCompleted(cliBuildRequest.Build.GithubRepo, cliBuildRequest.Build.Ref, false)
 	}
 	os.Exit(0)
 }

--- a/lib/metrics/metrics.go
+++ b/lib/metrics/metrics.go
@@ -19,6 +19,8 @@ type MetricsCollector interface {
 	BuildStarted(string, string) error
 	BuildFailed(string, string, bool) error
 	BuildSucceeded(string, string) error
+	TriggerFailed(string, string) error
+	TriggerSucceeded(string, string) error
 	KafkaProducerFailure() error
 	KafkaConsumerFailure() error
 	GCFailure() error
@@ -132,4 +134,14 @@ func (dc *DatadogCollector) DiskFree(bytes uint64) error {
 // FileNodesFree reports the number of file nodes (inodes) left on the Docker volume
 func (dc *DatadogCollector) FileNodesFree(nodes uint64) error {
 	return dc.c.Gauge("file_nodes_free", float64(nodes), nil, 1)
+}
+
+// TriggerFailed reports a trigger failure
+func (dc *DatadogCollector) TriggerFailed(repo, ref string) error {
+	return dc.c.Count("trigger.completed", 1, append(dc.tags(repo,ref), "failed:true"), 1)
+}
+
+// TriggerSucceeded reports a trigger success
+func (dc *DatadogCollector) TriggerSucceeded(repo, ref string) error {
+	return dc.c.Count("trigger.completed", 1, append(dc.tags(repo,ref), "failed:false"), 1)
 }

--- a/lib/metrics/metrics.go
+++ b/lib/metrics/metrics.go
@@ -19,8 +19,7 @@ type MetricsCollector interface {
 	BuildStarted(string, string) error
 	BuildFailed(string, string, bool) error
 	BuildSucceeded(string, string) error
-	TriggerFailed(string, string) error
-	TriggerSucceeded(string, string) error
+	TriggerCompleted(string, string, bool) error
 	KafkaProducerFailure() error
 	KafkaConsumerFailure() error
 	GCFailure() error
@@ -136,12 +135,8 @@ func (dc *DatadogCollector) FileNodesFree(nodes uint64) error {
 	return dc.c.Gauge("file_nodes_free", float64(nodes), nil, 1)
 }
 
-// TriggerFailed reports a trigger failure
-func (dc *DatadogCollector) TriggerFailed(repo, ref string) error {
-	return dc.c.Count("trigger.completed", 1, append(dc.tags(repo,ref), "failed:true"), 1)
-}
-
-// TriggerSucceeded reports a trigger success
-func (dc *DatadogCollector) TriggerSucceeded(repo, ref string) error {
-	return dc.c.Count("trigger.completed", 1, append(dc.tags(repo,ref), "failed:false"), 1)
+// TriggerCompleted reports the completion of the "trigger" subcommand
+func (dc *DatadogCollector) TriggerCompleted(repo, ref string, failed bool) error {
+	failedTag := fmt.Sprintf("failed=%v", failed)
+	return dc.c.Count("trigger.completed", 1, append(dc.tags(repo,ref), failedTag), 1)
 }

--- a/lib/mocks/mock_metrics_collector.go
+++ b/lib/mocks/mock_metrics_collector.go
@@ -227,3 +227,31 @@ func (mr *MockMetricsCollectorMockRecorder) Size(arg0, arg1, arg2, arg3, arg4 in
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockMetricsCollector)(nil).Size), arg0, arg1, arg2, arg3, arg4)
 }
+
+// TriggerFailed mocks base method
+func (m *MockMetricsCollector) TriggerFailed(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TriggerFailed", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TriggerFailed indicates an expected call of TriggerFailed
+func (mr *MockMetricsCollectorMockRecorder) TriggerFailed(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerFailed", reflect.TypeOf((*MockMetricsCollector)(nil).TriggerFailed), arg0, arg1)
+}
+
+// TriggerSucceeded mocks base method
+func (m *MockMetricsCollector) TriggerSucceeded(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TriggerSucceeded", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TriggerSucceeded indicates an expected call of TriggerSucceeded
+func (mr *MockMetricsCollectorMockRecorder) TriggerSucceeded(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerSucceeded", reflect.TypeOf((*MockMetricsCollector)(nil).TriggerSucceeded), arg0, arg1)
+}

--- a/lib/mocks/mock_metrics_collector.go
+++ b/lib/mocks/mock_metrics_collector.go
@@ -228,30 +228,16 @@ func (mr *MockMetricsCollectorMockRecorder) Size(arg0, arg1, arg2, arg3, arg4 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockMetricsCollector)(nil).Size), arg0, arg1, arg2, arg3, arg4)
 }
 
-// TriggerFailed mocks base method
-func (m *MockMetricsCollector) TriggerFailed(arg0, arg1 string) error {
+// TriggerCompleted mocks base method
+func (m *MockMetricsCollector) TriggerCompleted(arg0, arg1 string, arg2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TriggerFailed", arg0, arg1)
+	ret := m.ctrl.Call(m, "TriggerCompleted", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// TriggerFailed indicates an expected call of TriggerFailed
-func (mr *MockMetricsCollectorMockRecorder) TriggerFailed(arg0, arg1 interface{}) *gomock.Call {
+// TriggerCompleted indicates an expected call of TriggerCompleted
+func (mr *MockMetricsCollectorMockRecorder) TriggerCompleted(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerFailed", reflect.TypeOf((*MockMetricsCollector)(nil).TriggerFailed), arg0, arg1)
-}
-
-// TriggerSucceeded mocks base method
-func (m *MockMetricsCollector) TriggerSucceeded(arg0, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TriggerSucceeded", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// TriggerSucceeded indicates an expected call of TriggerSucceeded
-func (mr *MockMetricsCollectorMockRecorder) TriggerSucceeded(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerSucceeded", reflect.TypeOf((*MockMetricsCollector)(nil).TriggerSucceeded), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerCompleted", reflect.TypeOf((*MockMetricsCollector)(nil).TriggerCompleted), arg0, arg1, arg2)
 }


### PR DESCRIPTION
Currently, all of the metric collection is done server side. This is useful for most scenarios. 

However, one potential use case for Furan is to use `furan trigger` within some pipeline. `furan trigger` can fail even if the server was able to build and push the image successfully. This is because it communicates the server to check on the status of the build (which can fail). 

This patch adds the ability to collect metrics from the `furan trigger` command itself. This way, users can add monitors around this metric and act accordingly. 

If for some reason, the `MetricsCollector` fails to be created, the `trigger` command will just continue to operate the same as it did before. 