### PR TITLE
Local Acyl environment fixes

### DIFF
--- a/.helm/charts/consul/templates/service.yaml
+++ b/.helm/charts/consul/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{ if .Values.env_name }}
+  name: 'furan-{{ .Values.service.name }}'
+  {{- else }}
   name: {{ .Values.service.name }}
+  {{- end }}
   labels:
     app: {{ template "consul.name" . }}
     chart: {{ template "consul.chart" . }}

--- a/.helm/charts/furan/templates/deployment.yaml
+++ b/.helm/charts/furan/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: docker
         image: docker:17.06.1-ce-dind
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
           - --storage-driver=overlay2
         securityContext:
@@ -93,6 +93,9 @@ spec:
         {{ end }}
           - --docker-storage-path
           - /opt/docker-storage
+        {{ if .Values.metrics_disabled }}
+          - '--disable-metrics'
+        {{ end }}
         {{ if .Values.datadog.statsdAddr }}
           - --dogstatsd-addr={{ .Values.datadog.statsdAddr }}
         {{ end }}

--- a/.helm/charts/furan/values.yaml
+++ b/.helm/charts/furan/values.yaml
@@ -24,6 +24,14 @@ service:
   httpHealthcheckPath: /health
   performanceProfilingPort: 4003
 
+metrics_disabled: true
+
+datadog:
+  overrideDefaultTags: 'env:dev'
+  statsdAddr: datadog.tools.svc.cluster.local:8125
+  tracingAgentAddr: datadog.tools.svc.cluster.local:8126
+  serviceName: furan-dqa
+
 db:
   useConsulDiscovery: false
   nodes: "scylladb"

--- a/.helm/charts/furan/values.yaml
+++ b/.helm/charts/furan/values.yaml
@@ -34,17 +34,17 @@ datadog:
 
 db:
   useConsulDiscovery: false
-  nodes: "scylladb"
+  nodes: "furan-scylladb"
   initialize: true
-kafkaBrokers: "kafka-furan:9092"
+kafkaBrokers: "furan-kafka-furan:9092"
 
 vault:
   useTokenAuth: true
   useK8sAuth: false
-  addr: "http://vault:8200"
+  addr: "http://furan-vault:8200"
   token: "root"
 
-consulAddr: "consul:8500"
+consulAddr: "furan-consul:8500"
 
 ramdisk:
   enabled: false

--- a/.helm/charts/kafka/templates/deployment.yaml
+++ b/.helm/charts/kafka/templates/deployment.yaml
@@ -30,8 +30,13 @@ spec:
               fieldPath: status.podIP
         - name: KAFKA_ADVERTISED_LISTENERS
           value: "PLAINTEXT://$(POD_IP):{{ .Values.service.externalPort }}"
+        {{ if .Values.env_name }}
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: "furan-{{ .Values.zookeeper.service.name }}:{{ .Values.zookeeper.service.externalPort }}"
+        {{ else }}
         - name: KAFKA_ZOOKEEPER_CONNECT
           value: "{{ .Values.zookeeper.service.name }}:{{ .Values.zookeeper.service.externalPort }}"
+        {{ end }}
         # This is needed when you are running with a single-node cluster.
         {{ if eq .Values.app.replicas 1.0 }}
         - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR

--- a/.helm/charts/kafka/templates/service.yaml
+++ b/.helm/charts/kafka/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{ if .Values.env_name }}
+  name: 'furan-{{ .Values.service.name }}'
+  {{- else }}
   name: {{ .Values.service.name }}
+  {{- end }}
   labels:
     app: {{ template "kafka.name" . }}
     chart: {{ template "kafka.chart" . }}

--- a/.helm/charts/kafka/values.yaml
+++ b/.helm/charts/kafka/values.yaml
@@ -30,8 +30,9 @@ app:
 
 service:
   type: ClusterIP
-  # Note: This cannot be "kafka", otherwise, it will overwrite the env
-  # "KAFKA_PORT", which is used by the underyling docker container.
+  # Note: This cannot be "kafka", otherwise the service discovery env vars created automatically by k8s will collide
+  # with "KAFKA_PORT", which is used by the underyling docker container for configuration purposes.
+  # see https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
   name: kafka-furan
   internalPort: 9092
   externalPort: 9092

--- a/.helm/charts/scylladb/templates/configmap.yaml
+++ b/.helm/charts/scylladb/templates/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   liveness-probe.sh: |
     #!/bin/bash
-    cqlsh -e "CREATE KEYSPACE IF NOT EXISTS furan WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } AND DURABLE_WRITES = true;"
+    CQLSH_HOST=$(hostname -i) cqlsh -e "CREATE KEYSPACE IF NOT EXISTS furan WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } AND DURABLE_WRITES = true;"

--- a/.helm/charts/scylladb/templates/deployment.yaml
+++ b/.helm/charts/scylladb/templates/deployment.yaml
@@ -27,23 +27,23 @@ spec:
     {{ toYaml .Values.resources | indent 10 }}
           ports:
           - containerPort: {{ .Values.service.cqlInternalPort }}
+          command:
+            - /bin/bash
           args:
-          {{- if .Values.app.overprovisioned }}
-          - --overprovisioned
-          - {{ .Values.app.overprovisioned | quote }}
-          {{- end }}
+            - '-c'
+            - '/start-scylla; tail -f /dev/null'
           volumeMounts:
             - name: scylla-scripts
               mountPath: /k8s
           livenessProbe:
             exec:
-              command: ["/bin/sh", "-c", "/k8s/liveness-probe.sh"]
+              command: ["/bin/sh", "-c", ". /k8s/liveness-probe.sh"]
             initialDelaySeconds: 60
             failureThreshold: 2
             successThreshold: 1
           readinessProbe:
             exec:
-              command: ["/bin/sh", "-c", "/k8s/liveness-probe.sh"]
+              command: ["/bin/sh", "-c", ". /k8s/liveness-probe.sh"]
             failureThreshold: 2
             successThreshold: 1
             initialDelaySeconds: 10

--- a/.helm/charts/scylladb/templates/service.yaml
+++ b/.helm/charts/scylladb/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{ if .Values.env_name }}
+  name: 'furan-{{ .Values.service.name }}'
+  {{- else }}
   name: {{ template "scylladb.fullname" . }}
+  {{- end }}
   labels:
     app: {{ template "scylladb.name" . }}
     chart: {{ template "scylladb.chart" . }}

--- a/.helm/charts/scylladb/values.yaml
+++ b/.helm/charts/scylladb/values.yaml
@@ -3,11 +3,8 @@
 # Declare variables to be passed into your templates.
 image:
   repository: scylladb/scylla
-  tag: 1.7.3
+  tag: 1.1.0
   pullPolicy: Always
-
-app:
-  overprovisioned: 1
 
 service:
   name: scylladb

--- a/.helm/charts/scylladb/values.yaml
+++ b/.helm/charts/scylladb/values.yaml
@@ -10,7 +10,7 @@ app:
   overprovisioned: 1
 
 service:
-  name: cql
+  name: scylladb
   type: ClusterIP
   cqlInternalPort: 9042
   cqlExternalPort: 9042

--- a/.helm/charts/vault/templates/service.yaml
+++ b/.helm/charts/vault/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{ if .Values.env_name }}
+  name: 'furan-{{ .Values.service.name }}'
+  {{- else }}
   name: {{ template "vault.fullname" . }}
+  {{- end }}
   labels:
     app: {{ template "vault.name" . }}
     chart: {{ template "vault.chart" . }}

--- a/.helm/charts/vault/templates/service.yaml
+++ b/.helm/charts/vault/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   {{ if .Values.env_name }}
   name: 'furan-{{ .Values.service.name }}'
   {{- else }}
-  name: {{ template "vault.fullname" . }}
+  name: {{ .Values.service.name }}
   {{- end }}
   labels:
     app: {{ template "vault.name" . }}

--- a/.helm/charts/vault/values.yaml
+++ b/.helm/charts/vault/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: Always
 
 service:
-  name: http
+  name: vault
   type: ClusterIP
   ports:
     internalPort: 8200

--- a/.helm/charts/zookeeper/templates/service.yaml
+++ b/.helm/charts/zookeeper/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{ if .Values.env_name }}
+  name: 'furan-{{ .Values.service.name }}'
+  {{- else }}
   name: {{ template "zookeeper.fullname" . }}
+  {{- end }}
   labels:
     app: {{ template "zookeeper.name" . }}
     chart: {{ template "zookeeper.chart" . }}

--- a/acyl.yml
+++ b/acyl.yml
@@ -15,6 +15,9 @@ application:
     - "docker_resources.requests.cpu=20m"
     - "image.pullPolicy=IfNotPresent"
     - "metrics_disabled=true"
+    - "vault.addr=http://furan-vault:8200"
+    - "db.nodes=furan-scylladb"
+    - "kafkaBrokers=furan-kafka-furan:9092"
 
 dependencies:
   direct:

--- a/acyl.yml
+++ b/acyl.yml
@@ -8,6 +8,13 @@ application:
   chart_path: '.helm/charts/furan'
   chart_vars_repo_path: 'dollarshaveclub/helm-charts@master:releases/kube-uw2-110/furan/dqa.yaml'
   image: quay.io/dollarshaveclub/furan
+  value_overrides:
+    - "resources.requests.memory=100M"
+    - "resources.requests.cpu=10m"
+    - "docker_resources.requests.memory=200M"
+    - "docker_resources.requests.cpu=20m"
+    - "image.pullPolicy=IfNotPresent"
+    - "metrics_disabled=true"
 
 dependencies:
   direct:

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -84,7 +84,7 @@ type Serverconfig struct {
 	S3PresignTTL        uint
 	GCIntervalSecs      uint
 	DockerDiskPath      string
-	DisableMetrics bool
+	DisableMetrics 		bool
 }
 
 type Consulconfig struct {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -84,6 +84,7 @@ type Serverconfig struct {
 	S3PresignTTL        uint
 	GCIntervalSecs      uint
 	DockerDiskPath      string
+	DisableMetrics bool
 }
 
 type Consulconfig struct {

--- a/lib/metrics/fake.go
+++ b/lib/metrics/fake.go
@@ -1,0 +1,21 @@
+package metrics
+
+type FakeCollector struct{}
+
+func (fc *FakeCollector) Duration(string, string, string, []string, float64) error { return nil }
+func (fc *FakeCollector) Size(string, string, string, []string, int64) error       { return nil }
+func (fc *FakeCollector) Float(string, string, string, []string, float64) error    { return nil }
+func (fc *FakeCollector) ImageSize(int64, int64, string, string) error             { return nil }
+func (fc *FakeCollector) BuildStarted(string, string) error                        { return nil }
+func (fc *FakeCollector) BuildFailed(string, string, bool) error                   { return nil }
+func (fc *FakeCollector) BuildSucceeded(string, string) error                      { return nil }
+func (fc *FakeCollector) TriggerCompleted(string, string, bool) error              { return nil }
+func (fc *FakeCollector) KafkaProducerFailure() error                              { return nil }
+func (fc *FakeCollector) KafkaConsumerFailure() error                              { return nil }
+func (fc *FakeCollector) GCFailure() error                                         { return nil }
+func (fc *FakeCollector) GCUntaggedImageRemoved() error                            { return nil }
+func (fc *FakeCollector) GCBytesReclaimed(uint64) error                            { return nil }
+func (fc *FakeCollector) DiskFree(uint64) error                                    { return nil }
+func (fc *FakeCollector) FileNodesFree(uint64) error                               { return nil }
+
+var _ MetricsCollector = &FakeCollector{}

--- a/lib/metrics/metrics.go
+++ b/lib/metrics/metrics.go
@@ -35,6 +35,8 @@ type DatadogCollector struct {
 	defaultTags []string
 }
 
+var _ MetricsCollector = &DatadogCollector{}
+
 // NewDatadogCollector returns a DatadogCollector using dogstatsd at addr
 func NewDatadogCollector(addr string, defaultTags []string) (*DatadogCollector, error) {
 	c, err := statsd.New(addr)


### PR DESCRIPTION
Various fixes needed to include Furan as a repo-style dependency in local Acyl DQA environments (minikube, etc) to allow them to function fully.

- Add `--disable-metrics` CLI flag to allow Furan to not error out when Datadog isn't available.
- Conditionally prefix all service names with `furan-` to make Furan dependencies discoverable and private when included as transitive dependencies.
- Greatly reduce DinD resource requests to make it schedulable in a local k8s cluster. 