### PR TITLE
helm: add mtu value for dind container

### DIFF
--- a/.helm/charts/furan/templates/deployment.yaml
+++ b/.helm/charts/furan/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
           - --storage-driver=overlay2
+          - --mtu={{ .Values.dind.mtu }}
         securityContext:
           privileged: true
         volumeMounts:

--- a/.helm/charts/furan/values.yaml
+++ b/.helm/charts/furan/values.yaml
@@ -49,5 +49,8 @@ consulAddr: "furan-consul:8500"
 ramdisk:
   enabled: false
 
+dind:
+  mtu: 1500
+
 dnsPolicy: ClusterFirst
 dnsConfig: {}


### PR DESCRIPTION
Max found an issue where the MTU being used by Docker was greater than the MTU set for the underlying interface.

To solve this issue, we should make this MTU value configurable to allow developers to set this value as needed. 

Issue described in detail in a few different blogs: 

https://mlohr.com/docker-mtu/