### PR TITLE
Better job handoff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.15
+      - image: circleci/postgres:12-alpine-ram
         environment:
-          SCYLLA_TEST_NODE: scylla:9042
-      - image: scylladb/scylla:1.6.6
-        name: scylla
-        command: --memory 512M --smp 2
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: root
+          POSTGRES_DB: postgres
 
     working_directory: /go/src/github.com/dollarshaveclub/furan
     steps:
@@ -18,11 +18,21 @@ jobs:
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
-
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://scylla:9042 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
 
-      - run: go get -v -t -d ./...
-      - run: go vet $(go list ./... |grep lib/)
-      - run: go test -v $(go list ./... |grep /lib/)
+      - run: go mod vendor
+      - run:
+          name: Run vet
+          command: go vet ./...
+      - run:
+          name: Run tests
+          working_directory: ./pkg
+          environment:
+            FURAN_TEST_DB: postgresql://postgres:root@localhost:5432/postgres?sslmode=disable
+          command: go test -coverprofile=profile.cov ./...
+      - run:
+          name: Test coverage
+          working_directory: ./pkg
+          command: go tool cover -func profile.cov |grep total |awk '{ print $3 }'

--- a/cmd/runbuild.go
+++ b/cmd/runbuild.go
@@ -94,6 +94,11 @@ func runbuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid build id: %w", err)
 	}
 
+	// verify that buildkitd is up and running
+	if err := bks.VerifyAddr(); err != nil {
+		return fmt.Errorf("error connecting to buildkitd: %v", err)
+	}
+
 	ctx, cf := context.WithTimeout(context.Background(), runbuildtimeout)
 	defer cf()
 

--- a/migrations/0001_initial.up.sql
+++ b/migrations/0001_initial.up.sql
@@ -17,7 +17,7 @@ CREATE TABLE builds (
   events text[]  -- ordered array of build event strings
 );
 
---CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 CREATE TABLE api_keys (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -198,7 +198,7 @@ var (
 
 // verifyAddr ensures that the buildkit socket is connectable, returning an error if timeout is reached and
 // the socket is still unavailable
-func (bks *BuildSolver) verifyAddr() error {
+func (bks *BuildSolver) VerifyAddr() error {
 	deadline := time.Now().UTC().Add(SocketConnectTimeout)
 	for {
 		now := time.Now().UTC()
@@ -286,7 +286,7 @@ func (bks *BuildSolver) Build(ctx context.Context, opts models.BuildOpts) error 
 	}()
 
 	// make sure the buildkit socket is available
-	if err := bks.verifyAddr(); err != nil {
+	if err := bks.VerifyAddr(); err != nil {
 		return fmt.Errorf("error verifying that buildkit is available: %w", err)
 	}
 

--- a/pkg/datalayer/testsuite/testsuite.go
+++ b/pkg/datalayer/testsuite/testsuite.go
@@ -326,7 +326,7 @@ func testDBSetBuildCompletedTimestamp(t *testing.T, dl datalayer.DataLayer) {
 	if err != nil {
 		t.Fatalf("error getting build by id: %v", err)
 	}
-	if b.Completed.UTC() != now {
+	if b.Completed.UTC().Truncate(time.Second) != now.Truncate(time.Second) {
 		t.Fatalf("bad completed timestamp: %v (expected %v)", b.Completed.UTC(), now)
 	}
 	err = dl.DeleteBuild(context.Background(), id)


### PR DESCRIPTION
Tweaks to make build handoff more robust

- Check the buildkitd socket is available earlier, before handoff
- Handle signals after handoff and abort build cleanly